### PR TITLE
fix XMPP single-user messages and go-xmpp API change

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func (output *xmppCommon) Connect() error {
 	output.talk = talk
 
 	if output.join {
-		talk.JoinMUC(output.to, output.nick)
+		talk.JoinMUCNoHistory(output.to, output.nick)
 		log.Printf("xmpp: joined <%s> as <%s>\n", output.to, output.nick)
 	}
 
@@ -103,7 +103,7 @@ func (output *xmppCommon) Connect() error {
 }
 
 func (output *xmppCommon) Write(p []byte) (n int, err error) {
-	msgType := "normal"
+	msgType := "chat"
 	if output.join {
 		msgType = "groupchat"
 	}


### PR DESCRIPTION
Fix sending messages directly to a single user (msgType was wrong).
And fix compiling with a current go-xmpp version (#9)